### PR TITLE
Update pdns submodule to point to desec-io pdns fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pdns"]
 	path = pdns
-	url = https://github.com/jgoertzen-sb/pdns
+	url = https://github.com/desec-io/pdns


### PR DESCRIPTION
This PR updates the pdns submodule to use the desec-io fork which contains the implementations for Falcon512, Dilithium2, Sphincs+-SHA256-128s, XMSS, and XMSSMT.